### PR TITLE
Fix crash when jumping to definition (#276)

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -417,7 +417,7 @@ class JediCompletion(object):
                     "text": definition.name,
                     "type": self._get_definition_type(definition),
                     "raw_type": definition.type,
-                    "fileName": module_path,
+                    "fileName": str(module_path),
                     "container": container,
                     "range": definitionRange,
                     "description": definition.description,


### PR DESCRIPTION
Newer versions of Jedi return a `Path` object rather than a `str` for
paths. This simple changes makes sure we cast it string before
serialising as JSON.

This works with both older Jedis and with the latest version / master.